### PR TITLE
check Python version on startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# VS Code
+.vscode/
 # Config file
 config.yaml
 # Default output file for list_all.py

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ BT tracking is not an exact science. Here's a non-exhaustive list of issues that
   Note: raspberry 3 and later have an integrated BT adapter.
 * Linux installed on the BT scanner: while Python is cross platform, this app depends on the `btmgmt` utility that is only available on Linux.
 * The `bluetoothctl` and `btmgmt` commands are installed on the BT scanner. If missing, `apt install bluez` may fix it.
-* Python 3.9 and pip3 installed on the BT scanner. Run `sudo apt-get install python3-pip` if missing.
+* Python 3.9+ and pip3 installed on the BT scanner. Run `sudo apt-get install python3-pip` if missing.
 * Passwordless `sudo` permissions for the account running the app (a `btmgmt` requirement).
 * Note: app can run in a [Docker](https://www.docker.com/) container on the BT scanner (instructions below). It is however recommended to do initial setup directly on the host.
 

--- a/main.py
+++ b/main.py
@@ -2,7 +2,9 @@
 
 from pathlib import Path
 import logging
+import platform
 from time import sleep
+import sys
 import yaml
 
 from collector import Collector
@@ -42,9 +44,15 @@ def report(runs: int, devices: dict, hubitat: Hubitat) -> None:
 
 
 CONFIG_FILE = "config.yaml"
+SUPPORTED_PYTHON_MAJOR = 3
+SUPPORTED_PYTHON_MINOR = 9
 
 
 def main() -> None:
+
+    if sys.version_info < (SUPPORTED_PYTHON_MAJOR, SUPPORTED_PYTHON_MINOR):
+        raise Exception(f"Python version {SUPPORTED_PYTHON_MAJOR}.{SUPPORTED_PYTHON_MINOR} or later required. Actual version: {platform.python_version()}.")
+
     try:
         with open(Path(__file__).with_name(CONFIG_FILE)) as config_file:
 

--- a/main.py
+++ b/main.py
@@ -51,7 +51,7 @@ SUPPORTED_PYTHON_MINOR = 9
 def main() -> None:
 
     if sys.version_info < (SUPPORTED_PYTHON_MAJOR, SUPPORTED_PYTHON_MINOR):
-        raise Exception(f"Python version {SUPPORTED_PYTHON_MAJOR}.{SUPPORTED_PYTHON_MINOR} or later required. Actual version: {platform.python_version()}.")
+        raise Exception(f"Python version {SUPPORTED_PYTHON_MAJOR}.{SUPPORTED_PYTHON_MINOR} or later required. Current version: {platform.python_version()}.")
 
     try:
         with open(Path(__file__).with_name(CONFIG_FILE)) as config_file:


### PR DESCRIPTION
Closes #5 

Tested by simulating 3.10 is needed; error msg:
`Exception: Python version 3.10 or later required. Current version: 3.9.13.`